### PR TITLE
Add Basic support for ISteamGameServer_UserHasLicenseForApp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-project(SmokeAPI VERSION 2.0.5)
+project(SmokeAPI VERSION 2.0.51)
 
 include(KoalaBox/cmake/KoalaBox.cmake)
 
@@ -69,6 +69,8 @@ set(
     src/steam_impl/steam_inventory.hpp
     src/steam_impl/steam_user.cpp
     src/steam_impl/steam_user.hpp
+	src/steam_impl/steam_game_server.cpp
+	src/steam_impl/steam_game_server.hpp
     src/main.cpp
     ${GENERATED_LINKER_EXPORTS}
 )

--- a/src/game_mode/exports/steam_api_flat.cpp
+++ b/src/game_mode/exports/steam_api_flat.cpp
@@ -2,6 +2,7 @@
 #include <steam_impl/steam_client.hpp>
 #include <steam_impl/steam_inventory.hpp>
 #include <steam_impl/steam_user.hpp>
+#include <steam_impl/steam_game_server.hpp>
 #include <steam_impl/steam_impl.hpp>
 #include <koalabox/logger.hpp>
 
@@ -249,6 +250,36 @@ DLL_EXPORT(EUserHasLicenseForAppResult) SteamAPI_ISteamUser_UserHasLicenseForApp
     } catch (const Exception& e) {
         LOG_ERROR("{} -> Error: {}", __func__, e.what())
         return k_EUserHasLicenseResultDoesNotHaveLicense;
+    }
+
+}
+
+// ISteamGameServer
+
+DLL_EXPORT(EUserHasLicenseForAppResult) SteamAPI_ISteamGameServer_UserHasLicenseForApp(
+    void* self,
+    CSteamID steamID,
+    AppId_t dlcID
+) {
+    try {
+        /*
+        Will crash here.
+        Probably because server only app don't need to init same interfaces used to recover the appID in the client (ISteamUser).
+        */
+        //static const auto app_id = steam_impl::get_app_id_or_throw();
+        // TODO : CLEAN THIS BY FINDING A WAY TO GET AppID FROM ISteamGameServer (hooking InitGameServer maybe ?)
+        static const auto app_id = 0; // Workaround
+        return steam_game_server::UserHasLicenseForApp(
+            __func__, app_id, dlcID, [&]() {
+                GET_ORIGINAL_FUNCTION_STEAMAPI(SteamAPI_ISteamGameServer_UserHasLicenseForApp)
+
+                    return SteamAPI_ISteamGameServer_UserHasLicenseForApp_o(self, steamID, dlcID);
+            }
+        );
+    }
+    catch (const Exception& e) {
+        LOG_ERROR("{} -> Error: {}", __func__, e.what())
+            return k_EUserHasLicenseResultDoesNotHaveLicense;
     }
 
 }

--- a/src/steam_impl/steam_game_server.cpp
+++ b/src/steam_impl/steam_game_server.cpp
@@ -1,0 +1,33 @@
+#include <steam_impl/steam_game_server.hpp>
+#include <smoke_api/config.hpp>
+#include <koalabox/logger.hpp>
+
+namespace steam_game_server {
+
+    EUserHasLicenseForAppResult UserHasLicenseForApp(
+        const String& function_name,
+        AppId_t appId,
+        AppId_t dlcId,
+        const Function<EUserHasLicenseForAppResult()>& original_function
+    ) {
+        const auto result = original_function();
+
+        if (result == k_EUserHasLicenseResultNoAuth) {
+            LOG_WARN("{} -> App ID: {:>8}, Result: NoAuth", function_name, dlcId)
+                return result;
+        }
+
+        const auto has_license = smoke_api::config::is_dlc_unlocked(
+            appId, dlcId, [&]() {
+                return result == k_EUserHasLicenseResultHasLicense;
+            }
+        );
+
+        LOG_INFO("{} -> App ID: {:>8}, HasLicense: {}", function_name, dlcId, has_license)
+
+            return has_license
+            ? k_EUserHasLicenseResultHasLicense
+            : k_EUserHasLicenseResultDoesNotHaveLicense;
+    }
+
+}

--- a/src/steam_impl/steam_game_server.hpp
+++ b/src/steam_impl/steam_game_server.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <core/types.hpp>
+
+namespace steam_game_server {
+
+    EUserHasLicenseForAppResult UserHasLicenseForApp(
+        const String& function_name,
+        AppId_t appId,
+        AppId_t dlcId,
+        const Function<EUserHasLicenseForAppResult()>& original_function
+    );
+
+}


### PR DESCRIPTION
Some games host server in the background when playing in solo/private games and use the ISteamGameServer_UserHasLicenseForApp instead of the ISteamUser_UserHasLicenseForApp to check if the user owns a specific piece of DLC.

This very basic implementation need some clean up/change at [steam_api_flat.cpp#L265](https://github.com/hZeper/SmokeAPI/blob/cac0311ea6d6f32d0ae0a689fca5b758a5ee60df/src/game_mode/exports/steam_api_flat.cpp#L265) before mergin.

Tested working on appID `1604030` in proxy mode.