### PR TITLE
feat: add optional achievement tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build
+/.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ set(SMOKE_API_STATIC_SOURCES
     static/smoke_api/interfaces/steam_inventory.cpp
     static/smoke_api/interfaces/steam_user.hpp
     static/smoke_api/interfaces/steam_user.cpp
+    static/smoke_api/interfaces/steam_user_stats.hpp
+    static/smoke_api/interfaces/steam_user_stats.cpp
     static/smoke_api/api.hpp
     static/smoke_api/api.cpp
     static/smoke_api/cache.hpp
@@ -44,12 +46,14 @@ set(SMOKE_API_SOURCES
     ${GENERATED_SOURCES}
     src/smoke_api/smoke_api.cpp
     src/smoke_api/smoke_api.hpp
+    src/steam_api/steam_api_flat.cpp
     src/steam_api/virtuals/isteamapps.cpp
     src/steam_api/virtuals/isteamclient.cpp
     src/steam_api/virtuals/isteamgameserver.cpp
     src/steam_api/virtuals/isteamhttp.cpp
     src/steam_api/virtuals/isteaminventory.cpp
     src/steam_api/virtuals/isteamuser.cpp
+    src/steam_api/virtuals/isteamuserstats.cpp
     src/steam_api/virtuals/steam_api_virtuals.hpp
     src/steam_api/steam_client.hpp
     src/steam_api/steam_client.cpp
@@ -60,7 +64,7 @@ set(SMOKE_API_SOURCES
 
 if(WIN32)
     set_32_and_64(STEAM_API_MODULE steam_api)
-    set_32_and_64(STEAMCLIENT_DLL steamclient)
+    set_32_and_64(STEAMCLIENT_DLL steamclient64.dll steamclient.dll)
 
     list(APPEND SMOKE_API_SOURCES src/main_win.cpp)
 else()

--- a/PULL_REQUEST.md
+++ b/PULL_REQUEST.md
@@ -1,0 +1,60 @@
+# Achievement Tracking Feature
+
+## Why this PR?
+
+I'm working on [SteamEcho](https://github.com/ttmassa/steamecho), a WPF app that displays real-time achievement notifications for Steam games. To make this work, I needed a way to intercept achievement calls from games in real-time and log them to a file that my app can monitor.
+
+Since SmokeAPI already hooks into the Steam API, adding achievement tracking here made more sense than writing a separate tool from scratch.
+
+## What it does
+
+Intercepts these Steam API calls and logs them to `achievements_notification.json`:
+- `GetAchievement` 
+- `SetAchievement` 
+- `ClearAchievement` 
+- `IndicateAchievementProgress` 
+- `StoreStats`
+
+Works with both virtual interface calls (`ISteamUserStats::GetAchievement`) and flat API exports (`SteamAPI_ISteamUserStats_GetAchievement`) since different games use different patterns.
+
+The JSON file stores each achievement once with its latest state, automatically deduplicating entries:
+```json
+[
+    {
+        "event": "achievement_queried",
+        "timestamp": "2025-10-23T14:41:43Z",
+        "achievement": {
+            "id": "FIRST_BOSS",
+            "unlocked": true
+        }
+    }
+]
+```
+
+## Configuration
+
+Disabled by default. Enable it in `SmokeAPI.config.json`:
+```json
+{
+  "track_achievements": true
+}
+```
+
+## Files changed
+
+**New files:**
+- `static/smoke_api/interfaces/steam_user_stats.hpp/cpp` - Achievement tracking implementation
+- `src/steam_api/virtuals/isteamuserstats.cpp` - Virtual interface hooks
+- `src/steam_api/steam_api_flat.cpp` - Flat API export wrappers
+
+**Modified files:**
+- `CMakeLists.txt` - Build configuration
+- `static/smoke_api/config.hpp` + `res/SmokeAPI.config.json` + `res/SmokeAPI.schema.json` - Config option
+- `src/steam_api/steam_interfaces.cpp` - Hook registration
+- `src/steam_api/virtuals/steam_api_virtuals.hpp` + `src/steam_api/virtuals/isteamclient.cpp` - Interface declarations
+- `src/smoke_api/smoke_api.hpp/cpp` - Helper functions
+- `README.md` - Documentation
+
+## Testing
+
+Tested with Tunic (553420) on Windows 11 64-bit in proxy mode. Successfully tracked 15 achievements with proper deduplication across multiple game launches.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ _Legit DLC ownership emulation for Steamworks._
 
 * `🔓` Emulate DLC ownership in legitimately owned games
 * `🛅` Emulate Inventory item ownership
+* `🏆` Optional achievement tracking to JSON file
 * `📄` Optional configuration
 * `🐧` Support for 32-bit and 64-bit Windows and Linux systems
 
@@ -262,6 +263,7 @@ Below you can find the detailed description of each available config option. In 
 | `override_dlc_status` | Overrides the status of individual DLCs, regardless of the corresponding app status. | Object | `{}` | An object with `"key": "value"` pairs, where key is DLC ID and value is DLC status. |
 | `auto_inject_inventory` | Specifies whether SmokeAPI should automatically inject a list of all registered inventory items, when a game queries user inventory | Boolean | `true` | `true` or `false`. |
 | `extra_inventory_items` | A list of inventory item IDs that will be added in addition to the automatically injected items. | Array | `[]` | An array of integer App IDs. |
+| `track_achievements` | Enables achievement tracking to `achievements_notification.json` file for external monitoring applications. | Boolean | `false` | `true` or `false`. |
 | `extra_dlcs` | See [Extra info](#-how-smokeapi-works-in-games-with-large-number-of-dlcs) to understand the use case for this option. | Object | `{}` | An object with `"key": "value"`, where the key is App ID and value is an object with `"dlcs"` property. See the complete example for more. |
 
 
@@ -306,6 +308,7 @@ Below you can find an example config where nearly every option has been customiz
     8765,
     7654
   ],
+  "track_achievements": false,
   "extra_dlcs": {
     "1234": {
       "dlcs": {
@@ -325,6 +328,32 @@ Below you can find an example config where nearly every option has been customiz
 
 
 ## 🎓 Extra info
+
+### 🏆 Achievement Tracking
+
+SmokeAPI includes an optional achievement tracking feature that monitors achievement-related Steam API calls and logs them to a JSON file. This is useful for:
+- External notification applications that display achievement popups
+- Achievement progress tracking tools
+- Game development and debugging
+- Achievement statistics collection
+
+When enabled via the `track_achievements` config option, SmokeAPI creates an `achievements_notification.json` file in the same directory as the DLL. This file contains a JSON array of achievement events with timestamps and unlock status.
+
+**Example output:**
+```json
+[
+    {
+        "event": "achievement_queried",
+        "timestamp": "2025-10-23T14:41:43Z",
+        "achievement": {
+            "id": "FIRST_BOSS",
+            "unlocked": true
+        }
+    }
+]
+```
+
+The tracking system automatically deduplicates achievements, so each achievement appears only once in the file with its most recent state. This feature has minimal performance impact and is disabled by default.
 
 ### 🔑 How SmokeAPI works in games with large number of DLCs
 

--- a/res/SmokeAPI.config.json
+++ b/res/SmokeAPI.config.json
@@ -3,6 +3,7 @@
   "$version": 4,
   "logging": true,
   "log_steam_http": false,
+  "track_achievements": false,
   "default_app_status": "unlocked",
   "override_app_status": {},
   "override_dlc_status": {},

--- a/res/SmokeAPI.schema.json
+++ b/res/SmokeAPI.schema.json
@@ -30,6 +30,12 @@
       "description": "Toggles logging of SteamHTTP traffic",
       "x-valid-values": "`true` or `false`."
     },
+    "track_achievements": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enables achievement tracking. When enabled, achievement API calls (get, set, clear, progress) are logged to achievements_notification.json next to the DLL for external monitoring.",
+      "x-valid-values": "`true` or `false`."
+    },
     "default_app_status": {
       "type": "string",
       "description": "Specifies default DLC status.",
@@ -124,6 +130,7 @@
       "$version": 4,
       "logging": true,
       "log_steam_http": true,
+      "track_achievements": false,
       "default_app_status": "unlocked",
       "override_app_status": {
         "1234": "original",

--- a/src/smoke_api/smoke_api.hpp
+++ b/src/smoke_api/smoke_api.hpp
@@ -7,4 +7,5 @@ namespace smoke_api {
     void shutdown();
 
     AppId_t get_app_id();
+    void* get_original_library();
 }

--- a/src/steam_api/steam_api_flat.cpp
+++ b/src/steam_api/steam_api_flat.cpp
@@ -1,0 +1,154 @@
+#include <koalabox/logger.hpp>
+#include <koalabox/lib.hpp>
+
+#include "smoke_api/smoke_api.hpp"
+#include "smoke_api/interfaces/steam_user_stats.hpp"
+
+// Flat API wrappers for ISteamUserStats
+// These override the auto-generated proxy exports
+
+extern "C" {
+
+__declspec(dllexport) bool SteamAPI_ISteamUserStats_GetAchievement(
+    void* self,
+    const char* pchName,
+    bool* pbAchieved
+) {
+    using FuncPtr = decltype(&SteamAPI_ISteamUserStats_GetAchievement);
+    static FuncPtr original = nullptr;
+    
+    if (!original) {
+        auto lib = smoke_api::get_original_library();
+        if (lib) {
+            original = reinterpret_cast<FuncPtr>(
+                koalabox::lib::get_function_address_or_throw(lib, "SteamAPI_ISteamUserStats_GetAchievement")
+            );
+        }
+    }
+    
+    if (!original) {
+        return false; // Library not yet loaded
+    }
+
+    return smoke_api::steam_user_stats::GetAchievement(
+        __func__,
+        smoke_api::get_app_id(),
+        pchName,
+        pbAchieved,
+        [=]() { return original(self, pchName, pbAchieved); }
+    );
+}
+
+__declspec(dllexport) bool SteamAPI_ISteamUserStats_SetAchievement(
+    void* self,
+    const char* pchName
+) {
+    using FuncPtr = decltype(&SteamAPI_ISteamUserStats_SetAchievement);
+    static FuncPtr original = nullptr;
+    
+    if (!original) {
+        auto lib = smoke_api::get_original_library();
+        if (lib) {
+            original = reinterpret_cast<FuncPtr>(
+                koalabox::lib::get_function_address_or_throw(lib, "SteamAPI_ISteamUserStats_SetAchievement")
+            );
+        }
+    }
+    
+    if (!original) {
+        return false; // Library not yet loaded
+    }
+
+    return smoke_api::steam_user_stats::SetAchievement(
+        __func__,
+        smoke_api::get_app_id(),
+        pchName,
+        [=]() { return original(self, pchName); }
+    );
+}
+
+__declspec(dllexport) bool SteamAPI_ISteamUserStats_ClearAchievement(
+    void* self,
+    const char* pchName
+) {
+    using FuncPtr = decltype(&SteamAPI_ISteamUserStats_ClearAchievement);
+    static FuncPtr original = nullptr;
+    
+    if (!original) {
+        auto lib = smoke_api::get_original_library();
+        if (lib) {
+            original = reinterpret_cast<FuncPtr>(
+                koalabox::lib::get_function_address_or_throw(lib, "SteamAPI_ISteamUserStats_ClearAchievement")
+            );
+        }
+    }
+    
+    if (!original) {
+        return false; // Library not yet loaded
+    }
+
+    return smoke_api::steam_user_stats::ClearAchievement(
+        __func__,
+        smoke_api::get_app_id(),
+        pchName,
+        [=]() { return original(self, pchName); }
+    );
+}
+
+__declspec(dllexport) bool SteamAPI_ISteamUserStats_IndicateAchievementProgress(
+    void* self,
+    const char* pchName,
+    uint32_t nCurProgress,
+    uint32_t nMaxProgress
+) {
+    using FuncPtr = decltype(&SteamAPI_ISteamUserStats_IndicateAchievementProgress);
+    static FuncPtr original = nullptr;
+    
+    if (!original) {
+        auto lib = smoke_api::get_original_library();
+        if (lib) {
+            original = reinterpret_cast<FuncPtr>(
+                koalabox::lib::get_function_address_or_throw(lib, "SteamAPI_ISteamUserStats_IndicateAchievementProgress")
+            );
+        }
+    }
+    
+    if (!original) {
+        return false; // Library not yet loaded
+    }
+
+    return smoke_api::steam_user_stats::IndicateAchievementProgress(
+        __func__,
+        smoke_api::get_app_id(),
+        pchName,
+        nCurProgress,
+        nMaxProgress,
+        [=]() { return original(self, pchName, nCurProgress, nMaxProgress); }
+    );
+}
+
+__declspec(dllexport) bool SteamAPI_ISteamUserStats_StoreStats(void* self) {
+    using FuncPtr = decltype(&SteamAPI_ISteamUserStats_StoreStats);
+    static FuncPtr original = nullptr;
+    
+    if (!original) {
+        auto lib = smoke_api::get_original_library();
+        if (lib) {
+            original = reinterpret_cast<FuncPtr>(
+                koalabox::lib::get_function_address_or_throw(lib, "SteamAPI_ISteamUserStats_StoreStats")
+            );
+        }
+    }
+    
+    if (!original) {
+        return false; // Library not yet loaded
+    }
+
+    return smoke_api::steam_user_stats::StoreStats(
+        __func__,
+        smoke_api::get_app_id(),
+        [=]() { return original(self); }
+    );
+}
+
+} // extern "C"

--- a/src/steam_api/steam_interfaces.cpp
+++ b/src/steam_api/steam_interfaces.cpp
@@ -56,6 +56,7 @@ namespace {
                         ENTRY(ISteamClient, GetISteamUser),
                         ENTRY(ISteamClient, GetISteamGenericInterface),
                         ENTRY(ISteamClient, GetISteamInventory),
+                        ENTRY(ISteamClient, GetISteamUserStats),
                     }
                 }
             },
@@ -100,6 +101,19 @@ namespace {
                     .fallback_version = "SteamUser023",
                     .entry_map = {
                         ENTRY(ISteamUser, UserHasLicenseForApp),
+                    }
+                }
+            },
+            {
+                "STEAMUSERSTATS_INTERFACE_VERSION",
+                interface_data_t{
+                    .fallback_version = "STEAMUSERSTATS_INTERFACE_VERSION012",
+                    .entry_map = {
+                        ENTRY(ISteamUserStats, GetAchievement),
+                        ENTRY(ISteamUserStats, SetAchievement),
+                        ENTRY(ISteamUserStats, ClearAchievement),
+                        ENTRY(ISteamUserStats, IndicateAchievementProgress),
+                        ENTRY(ISteamUserStats, StoreStats),
                     }
                 }
             },
@@ -208,7 +222,10 @@ namespace steam_interfaces {
             virtual_hook_map.erase(STEAM_CLIENT);
 
             // Map virtual hook map to a set of keys
-            const auto prefixes = std::views::keys(virtual_hook_map) | std::ranges::to<std::set>();
+            const auto prefixes = std::set<std::string>(
+                std::views::keys(virtual_hook_map).begin(),
+                std::views::keys(virtual_hook_map).end()
+            );
 
             const auto CreateInterface$ = KB_LIB_GET_FUNC(steamclient_handle, CreateInterface);
 

--- a/src/steam_api/virtuals/isteamclient.cpp
+++ b/src/steam_api/virtuals/isteamclient.cpp
@@ -64,3 +64,20 @@ VIRTUAL(void*) ISteamClient_GetISteamInventory(
         )
     );
 }
+
+VIRTUAL(void*) ISteamClient_GetISteamUserStats(
+    PARAMS(
+        const HSteamUser hSteamUser,
+        const HSteamPipe hSteamPipe,
+        const char* pchVersion
+    )
+) noexcept {
+    return steam_client::GetGenericInterface(
+        __func__,
+        pchVersion,
+        SWAPPED_CALL_CLOSURE(
+            ISteamClient_GetISteamUserStats,
+            ARGS(hSteamUser, hSteamPipe, pchVersion)
+        )
+    );
+}

--- a/src/steam_api/virtuals/isteamuserstats.cpp
+++ b/src/steam_api/virtuals/isteamuserstats.cpp
@@ -1,0 +1,60 @@
+#include <koalabox/logger.hpp>
+
+#include "smoke_api/smoke_api.hpp"
+#include "smoke_api/interfaces/steam_user_stats.hpp"
+#include "steam_api/virtuals/steam_api_virtuals.hpp"
+
+VIRTUAL(bool) ISteamUserStats_GetAchievement(
+    PARAMS(const char* pchName, bool* pbAchieved)
+) noexcept {
+    return smoke_api::steam_user_stats::GetAchievement(
+        __func__,
+        smoke_api::get_app_id(),
+        pchName,
+        pbAchieved,
+        SWAPPED_CALL_CLOSURE(ISteamUserStats_GetAchievement, ARGS(pchName, pbAchieved))
+    );
+}
+
+VIRTUAL(bool) ISteamUserStats_SetAchievement(
+    PARAMS(const char* pchName)
+) noexcept {
+    return smoke_api::steam_user_stats::SetAchievement(
+        __func__,
+        smoke_api::get_app_id(),
+        pchName,
+        SWAPPED_CALL_CLOSURE(ISteamUserStats_SetAchievement, ARGS(pchName))
+    );
+}
+
+VIRTUAL(bool) ISteamUserStats_ClearAchievement(
+    PARAMS(const char* pchName)
+) noexcept {
+    return smoke_api::steam_user_stats::ClearAchievement(
+        __func__,
+        smoke_api::get_app_id(),
+        pchName,
+        SWAPPED_CALL_CLOSURE(ISteamUserStats_ClearAchievement, ARGS(pchName))
+    );
+}
+
+VIRTUAL(bool) ISteamUserStats_IndicateAchievementProgress(
+    PARAMS(const char* pchName, uint32_t nCurProgress, uint32_t nMaxProgress)
+) noexcept {
+    return smoke_api::steam_user_stats::IndicateAchievementProgress(
+        __func__,
+        smoke_api::get_app_id(),
+        pchName,
+        nCurProgress,
+        nMaxProgress,
+        SWAPPED_CALL_CLOSURE(ISteamUserStats_IndicateAchievementProgress, ARGS(pchName, nCurProgress, nMaxProgress))
+    );
+}
+
+VIRTUAL(bool) ISteamUserStats_StoreStats(PARAMS()) noexcept {
+    return smoke_api::steam_user_stats::StoreStats(
+        __func__,
+        smoke_api::get_app_id(),
+        SWAPPED_CALL_CLOSURE(ISteamUserStats_StoreStats, ARGS())
+    );
+}

--- a/src/steam_api/virtuals/steam_api_virtuals.hpp
+++ b/src/steam_api/virtuals/steam_api_virtuals.hpp
@@ -13,6 +13,7 @@ VIRTUAL(void*) ISteamClient_GetISteamApps(PARAMS(HSteamUser, HSteamPipe, const c
 VIRTUAL(void*) ISteamClient_GetISteamUser(PARAMS(HSteamUser, HSteamPipe, const char*)) noexcept;
 VIRTUAL(void*) ISteamClient_GetISteamGenericInterface(PARAMS(HSteamUser, HSteamPipe, const char*)) noexcept;
 VIRTUAL(void*) ISteamClient_GetISteamInventory(PARAMS(HSteamUser, HSteamPipe, const char*)) noexcept;
+VIRTUAL(void*) ISteamClient_GetISteamUserStats(PARAMS(HSteamUser, HSteamPipe, const char*)) noexcept;
 VIRTUAL(void*) ISteamClient_GetISteamUtils(PARAMS(HSteamPipe, const char*)) noexcept; // Unhooked
 
 // ISteamHTTP
@@ -42,6 +43,13 @@ VIRTUAL(bool) ISteamInventory_CheckResultSteamID(PARAMS(SteamInventoryResult_t, 
 
 // ISteamUser
 VIRTUAL(EUserHasLicenseForAppResult) ISteamUser_UserHasLicenseForApp(PARAMS(CSteamID, AppId_t)) noexcept;
+
+// ISteamUserStats
+VIRTUAL(bool) ISteamUserStats_GetAchievement(PARAMS(const char*, bool*)) noexcept;
+VIRTUAL(bool) ISteamUserStats_SetAchievement(PARAMS(const char*)) noexcept;
+VIRTUAL(bool) ISteamUserStats_ClearAchievement(PARAMS(const char*)) noexcept;
+VIRTUAL(bool) ISteamUserStats_IndicateAchievementProgress(PARAMS(const char*, uint32_t, uint32_t)) noexcept;
+VIRTUAL(bool) ISteamUserStats_StoreStats(PARAMS()) noexcept;
 
 // ISteamUtils
 VIRTUAL(AppId_t) ISteamUtils_GetAppID(PARAMS()) noexcept; // Unhooked

--- a/static/smoke_api/config.hpp
+++ b/static/smoke_api/config.hpp
@@ -22,6 +22,7 @@ namespace smoke_api::config {
         uint32_t $version = 4;
         bool logging = false;
         bool log_steam_http = false;
+        bool track_achievements = false;
         AppStatus default_app_status = AppStatus::UNLOCKED;
         std::map<std::string, AppStatus> override_app_status;
         std::map<std::string, AppStatus> override_dlc_status;
@@ -34,6 +35,7 @@ namespace smoke_api::config {
             $version,
             logging,
             log_steam_http,
+            track_achievements,
             default_app_status,
             override_app_status,
             override_dlc_status,

--- a/static/smoke_api/interfaces/steam_user_stats.cpp
+++ b/static/smoke_api/interfaces/steam_user_stats.cpp
@@ -1,0 +1,229 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <mutex>
+#include <sstream>
+
+#include <koalabox/io.hpp>
+#include <koalabox/logger.hpp>
+#include <koalabox/paths.hpp>
+
+#include "smoke_api/config.hpp"
+#include "smoke_api/interfaces/steam_user_stats.hpp"
+
+namespace smoke_api::steam_user_stats {
+    namespace kb = koalabox;
+
+    std::mutex notification_mutex;
+
+    std::string get_iso_timestamp() {
+        auto now = std::chrono::system_clock::now();
+        auto time_t_now = std::chrono::system_clock::to_time_t(now);
+        
+        std::tm tm_now{};
+#ifdef _WIN32
+        gmtime_s(&tm_now, &time_t_now);
+#else
+        gmtime_r(&time_t_now, &tm_now);
+#endif
+        
+        std::ostringstream oss;
+        oss << std::put_time(&tm_now, "%Y-%m-%dT%H:%M:%SZ");
+        return oss.str();
+    }
+
+    void write_achievement_notification(
+        AppId_t app_id,
+        const std::string& event_type,
+        const std::string& achievement_id,
+        bool unlocked,
+        uint32_t current_progress = 0,
+        uint32_t max_progress = 0
+    ) {
+        if (!config::instance.track_achievements) {
+            return;
+        }
+
+        try {
+            std::lock_guard<std::mutex> lock(notification_mutex);
+
+            const auto notification_path = kb::paths::get_self_dir() / "achievements_notification.json";
+
+            // Read existing JSON array or create new one
+            nlohmann::json achievements_array = nlohmann::json::array();
+            
+            if (std::filesystem::exists(notification_path)) {
+                try {
+                    const auto existing_content = kb::io::read_file(notification_path);
+                    if (!existing_content.empty()) {
+                        achievements_array = nlohmann::json::parse(existing_content);
+                        
+                        // Ensure it's an array
+                        if (!achievements_array.is_array()) {
+                            achievements_array = nlohmann::json::array();
+                        }
+                    }
+                } catch (const std::exception& e) {
+                    LOG_WARN("Failed to parse existing achievements file, creating new: {}", e.what());
+                    achievements_array = nlohmann::json::array();
+                }
+            }
+
+            // Create new achievement entry
+            nlohmann::ordered_json new_entry;
+            new_entry["event"] = event_type;
+            new_entry["timestamp"] = get_iso_timestamp();
+            
+            nlohmann::ordered_json achievement;
+            achievement["id"] = achievement_id;
+            achievement["unlocked"] = unlocked;
+            
+            new_entry["achievement"] = achievement;
+
+            // Check if achievement already exists and update it, otherwise append
+            bool found = false;
+            for (auto& entry : achievements_array) {
+                if (entry.contains("achievement") && 
+                    entry["achievement"].contains("id") && 
+                    entry["achievement"]["id"] == achievement_id) {
+                    // Update existing achievement with new data
+                    entry["event"] = event_type;
+                    entry["timestamp"] = get_iso_timestamp();
+                    entry["achievement"]["unlocked"] = unlocked;
+                    found = true;
+                    LOG_DEBUG("Achievement updated: {}", achievement_id);
+                    break;
+                }
+            }
+
+            if (!found) {
+                // Add new achievement
+                achievements_array.push_back(new_entry);
+                LOG_DEBUG("Achievement added: {}", achievement_id);
+            }
+
+            // Write the entire array back to file with pretty printing
+            const auto json_str = achievements_array.dump(4);
+            
+            if (kb::io::write_file(notification_path, json_str)) {
+                LOG_DEBUG("Achievement notification written: {}", achievement_id);
+            } else {
+                LOG_ERROR("Failed to write achievement notification for: {}", achievement_id);
+            }
+        } catch (const std::exception& e) {
+            LOG_ERROR("Error writing achievement notification: {}", e.what());
+        }
+    }
+
+    bool GetAchievement(
+        const char* function_name,
+        const AppId_t app_id,
+        const char* achievement_name,
+        bool* achieved,
+        const std::function<bool()>& original_function
+    ) noexcept {
+        const auto result = original_function();
+
+        if (config::instance.track_achievements && result && achieved && *achieved) {
+            LOG_INFO("{} -> Achievement queried: '{}' (unlocked: {})", function_name, achievement_name, *achieved);
+            write_achievement_notification(
+                app_id,
+                "achievement_queried",
+                achievement_name,
+                *achieved
+            );
+        }
+
+        return result;
+    }
+
+    bool SetAchievement(
+        const char* function_name,
+        const AppId_t app_id,
+        const char* achievement_name,
+        const std::function<bool()>& original_function
+    ) noexcept {
+        const auto result = original_function();
+
+        if (config::instance.track_achievements && result) {
+            LOG_INFO("{} -> Achievement unlocked: '{}'", function_name, achievement_name);
+            write_achievement_notification(
+                app_id,
+                "achievement_unlocked",
+                achievement_name,
+                true,
+                100,
+                100
+            );
+        }
+
+        return result;
+    }
+
+    bool ClearAchievement(
+        const char* function_name,
+        const AppId_t app_id,
+        const char* achievement_name,
+        const std::function<bool()>& original_function
+    ) noexcept {
+        const auto result = original_function();
+
+        if (config::instance.track_achievements && result) {
+            LOG_INFO("{} -> Achievement cleared: '{}'", function_name, achievement_name);
+            write_achievement_notification(
+                app_id,
+                "achievement_cleared",
+                achievement_name,
+                false
+            );
+        }
+
+        return result;
+    }
+
+    bool IndicateAchievementProgress(
+        const char* function_name,
+        const AppId_t app_id,
+        const char* achievement_name,
+        const uint32_t current_progress,
+        const uint32_t max_progress,
+        const std::function<bool()>& original_function
+    ) noexcept {
+        const auto result = original_function();
+
+        if (config::instance.track_achievements && result) {
+            LOG_INFO(
+                "{} -> Achievement progress: '{}' ({}/{})",
+                function_name,
+                achievement_name,
+                current_progress,
+                max_progress
+            );
+            write_achievement_notification(
+                app_id,
+                "achievement_progress",
+                achievement_name,
+                current_progress >= max_progress,
+                current_progress,
+                max_progress
+            );
+        }
+
+        return result;
+    }
+
+    bool StoreStats(
+        const char* function_name,
+        const AppId_t app_id,
+        const std::function<bool()>& original_function
+    ) noexcept {
+        const auto result = original_function();
+
+        if (config::instance.track_achievements && result) {
+            LOG_DEBUG("{} -> Stats stored to Steam", function_name);
+        }
+
+        return result;
+    }
+}

--- a/static/smoke_api/interfaces/steam_user_stats.hpp
+++ b/static/smoke_api/interfaces/steam_user_stats.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "smoke_api/types.hpp"
+
+namespace smoke_api::steam_user_stats {
+    bool GetAchievement(
+        const char* function_name,
+        AppId_t app_id,
+        const char* achievement_name,
+        bool* achieved,
+        const std::function<bool()>& original_function
+    ) noexcept;
+
+    bool SetAchievement(
+        const char* function_name,
+        AppId_t app_id,
+        const char* achievement_name,
+        const std::function<bool()>& original_function
+    ) noexcept;
+
+    bool ClearAchievement(
+        const char* function_name,
+        AppId_t app_id,
+        const char* achievement_name,
+        const std::function<bool()>& original_function
+    ) noexcept;
+
+    bool IndicateAchievementProgress(
+        const char* function_name,
+        AppId_t app_id,
+        const char* achievement_name,
+        uint32_t current_progress,
+        uint32_t max_progress,
+        const std::function<bool()>& original_function
+    ) noexcept;
+
+    bool StoreStats(
+        const char* function_name,
+        AppId_t app_id,
+        const std::function<bool()>& original_function
+    ) noexcept;
+}


### PR DESCRIPTION
Hi @acidicoala,

I added a new achievement tracking feature. Everything is detailed in [PULL_REQUEST.md](https://github.com/ttmassa/SmokeAPI/blob/feature/achievement-tracking/PULL_REQUEST.md), but here's a short summary:

**What it does:**
Intercepts Steam achievement API calls and logs them to `achievements_notification.json` for external apps to monitor.

**Key points:**
- Disabled by default (`track_achievements: false`)
- Works with both virtual interface and flat API calls
- Tested with Tunic - 15 achievements tracked with proper deduplication